### PR TITLE
Fix naImpute() function

### DIFF
--- a/R/cmsClassifier.R
+++ b/R/cmsClassifier.R
@@ -192,7 +192,7 @@ naImpute <- function(Exp,G=NULL){
         if(!is.null(G)) {
             tmp <- as.data.frame(array(mm,dim=c(length(G),ncol(Exp))))
             rownames(tmp) <- G
-            names(tmp) <- names(Exp)
+            colnames(tmp) <- colnames(Exp)
             Exp <- rbind(Exp,tmp)
         }       
         Exp


### PR DESCRIPTION
Fixed bug in the naImpute() function as in [here](https://github.com/Sage-Bionetworks/CMSclassifier/issues/5)

The fix solves the error `Error in match.names(clabs, names(xi)) : 
  names do not match previous names`.

There is still another error when the test data does not contain info for all the genes in the training set. This error only affects the RF method but not the SSP.